### PR TITLE
Pass all arguments after -- to all `go test` calls

### DIFF
--- a/package-coverage/generator/coverage.go
+++ b/package-coverage/generator/coverage.go
@@ -37,13 +37,13 @@ func processAllDirs(basePath string, matcher *regexp.Regexp, logTag string, acti
 
 // this function will cause the generation of test coverage for the supplied directory and return the file path of the
 // resultant coverage file
-func generateCoverage(path string) {
+func generateCoverage(path string, verbose bool, goTestArgs []string) {
 	packageName := findPackageName(path)
 
 	fakeTestFile := addFakeTest(path, packageName)
 	defer removeFakeTest(fakeTestFile)
 
-	err := execCoverage(path, coverageFilename)
+	err := execCoverage(path, coverageFilename, verbose, goTestArgs)
 	if err != nil {
 		log.Printf("error generating coverage %s", err)
 	}
@@ -120,7 +120,7 @@ func removeFakeTest(filename string) {
 }
 
 // essentially call `go test` to generate the coverage
-var execCoverage = func(dir string, coverageFilename string) error {
+var execCoverage = func(dir, coverageFilename string, verbose bool, goTestArgs []string) error {
 	var stdErr bytes.Buffer
 
 	command := "go"
@@ -129,8 +129,11 @@ var execCoverage = func(dir string, coverageFilename string) error {
 		"-coverprofile=" + coverageFilename,
 	}
 
+	arguments = append(arguments, goTestArgs...)
+
 	cmd := exec.Command(command, arguments...)
 	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
 	cmd.Stderr = &stdErr
 
 	if err := cmd.Run(); err != nil {

--- a/package-coverage/generator/generator.go
+++ b/package-coverage/generator/generator.go
@@ -6,11 +6,11 @@ import "regexp"
 const UnknownPackage = "unknown"
 
 // Coverage will generate coverage for the supplied directory and any sub-directories that contain Go files
-func Coverage(basePath string, matcher *regexp.Regexp) {
-	processAllDirs(basePath, matcher, "coverage", generateCoverage)
+func Coverage(basePath string, matcher *regexp.Regexp, verbose bool, goTestArgs []string) {
+	processAllDirs(basePath, matcher, "coverage", func(path string) { generateCoverage(path, verbose, goTestArgs) })
 }
 
 // CoverageSingle will generate coverage for the supplied directory (and ignore all sub directories)
-func CoverageSingle(basePath string) {
-	generateCoverage(basePath)
+func CoverageSingle(basePath string, verbose bool, goTestArgs []string) {
+	generateCoverage(basePath, verbose, goTestArgs)
 }

--- a/package-coverage/main.go
+++ b/package-coverage/main.go
@@ -53,6 +53,7 @@ func main() {
 
 	startDir := utils.GetCurrentDir()
 	path := getPath()
+	goTestArgs := getGoTestArguments()
 
 	if ignoreDirs != "" {
 		matcher = regexp.MustCompile(ignoreDirs)
@@ -60,9 +61,9 @@ func main() {
 
 	if coverage {
 		if singleDir {
-			generator.CoverageSingle(path)
+			generator.CoverageSingle(path, verbose, goTestArgs)
 		} else {
-			generator.Coverage(path, matcher)
+			generator.Coverage(path, matcher, verbose, goTestArgs)
 		}
 	}
 
@@ -112,4 +113,9 @@ func getPath() string {
 		panic("Please include a directory as the last argument")
 	}
 	return path
+}
+
+func getGoTestArguments() []string {
+	args := flag.Args()
+	return args[1:]
 }

--- a/package-coverage/main.go
+++ b/package-coverage/main.go
@@ -117,5 +117,12 @@ func getPath() string {
 
 func getGoTestArguments() []string {
 	args := flag.Args()
-	return args[1:]
+
+	// We only assume what comes after -- to be `go test` arguments. If there are two arguments, we do not assume them
+	// to be `go test` arguments.
+	if (len(args) >= 2 && args[1] != "--") || len(args) < 3 {
+		return []string{}
+	}
+
+	return args[2:]
 }


### PR DESCRIPTION
This allows flags to be passed down to the `go test` invocation, such as by the IntelliJ Go plugin.