### PR TITLE
Fix support for the `-covermode=count` and `covermode=atomic` options

### DIFF
--- a/package-coverage/parser/line_parser.go
+++ b/package-coverage/parser/line_parser.go
@@ -52,5 +52,9 @@ func extractStatements(raw string) int {
 }
 
 func extractCovered(raw string) bool {
-	return raw == "1"
+	covered, err := strconv.Atoi(raw)
+	if err != nil {
+		panic(err)
+	}
+	return covered > 0
 }


### PR DESCRIPTION
In those modes, the number of passes over a line may be more than 1.