### PR TITLE
Allow specifying file patterns to ignore

### DIFF
--- a/package-coverage/generator/coverage.go
+++ b/package-coverage/generator/coverage.go
@@ -37,13 +37,13 @@ func processAllDirs(basePath string, matcher *regexp.Regexp, logTag string, acti
 
 // this function will cause the generation of test coverage for the supplied directory and return the file path of the
 // resultant coverage file
-func generateCoverage(path string) {
+func generateCoverage(path string, verbose bool, goTestArgs []string) {
 	packageName := findPackageName(path)
 
 	fakeTestFile := addFakeTest(path, packageName)
 	defer removeFakeTest(fakeTestFile)
 
-	err := execCoverage(path, coverageFilename)
+	err := execCoverage(path, coverageFilename, verbose, goTestArgs)
 	if err != nil {
 		log.Printf("error generating coverage %s", err)
 	}
@@ -120,7 +120,7 @@ func removeFakeTest(filename string) {
 }
 
 // essentially call `go test` to generate the coverage
-var execCoverage = func(dir string, coverageFilename string) error {
+var execCoverage = func(dir, coverageFilename string, verbose bool, goTestArgs []string) error {
 	var stdErr bytes.Buffer
 
 	command := "go"
@@ -129,8 +129,11 @@ var execCoverage = func(dir string, coverageFilename string) error {
 		"-coverprofile=" + coverageFilename,
 	}
 
+	arguments = append(arguments, goTestArgs...)
+
 	cmd := exec.Command(command, arguments...)
 	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
 	cmd.Stderr = &stdErr
 
 	if err := cmd.Run(); err != nil {

--- a/package-coverage/generator/coverage.go
+++ b/package-coverage/generator/coverage.go
@@ -37,7 +37,7 @@ func processAllDirs(basePath string, matcher *regexp.Regexp, logTag string, acti
 
 // this function will cause the generation of test coverage for the supplied directory and return the file path of the
 // resultant coverage file
-func generateCoverage(path string, verbose bool, goTestArgs []string) {
+func generateCoverage(path string, fileMatcher *regexp.Regexp, verbose bool, goTestArgs []string) {
 	packageName := findPackageName(path)
 
 	fakeTestFile := addFakeTest(path, packageName)

--- a/package-coverage/generator/generator.go
+++ b/package-coverage/generator/generator.go
@@ -6,11 +6,11 @@ import "regexp"
 const UnknownPackage = "unknown"
 
 // Coverage will generate coverage for the supplied directory and any sub-directories that contain Go files
-func Coverage(basePath string, matcher *regexp.Regexp) {
-	processAllDirs(basePath, matcher, "coverage", generateCoverage)
+func Coverage(basePath string, matcher *regexp.Regexp, verbose bool, goTestArgs []string) {
+	processAllDirs(basePath, matcher, "coverage", func(path string) { generateCoverage(path, verbose, goTestArgs) })
 }
 
 // CoverageSingle will generate coverage for the supplied directory (and ignore all sub directories)
-func CoverageSingle(basePath string) {
-	generateCoverage(basePath)
+func CoverageSingle(basePath string, verbose bool, goTestArgs []string) {
+	generateCoverage(basePath, verbose, goTestArgs)
 }

--- a/package-coverage/generator/generator.go
+++ b/package-coverage/generator/generator.go
@@ -6,11 +6,13 @@ import "regexp"
 const UnknownPackage = "unknown"
 
 // Coverage will generate coverage for the supplied directory and any sub-directories that contain Go files
-func Coverage(basePath string, matcher *regexp.Regexp, verbose bool, goTestArgs []string) {
-	processAllDirs(basePath, matcher, "coverage", func(path string) { generateCoverage(path, verbose, goTestArgs) })
+func Coverage(basePath string, dirMatcher, fileMatcher *regexp.Regexp, verbose bool, goTestArgs []string) {
+	processAllDirs(basePath, dirMatcher, "coverage", func(path string) {
+		generateCoverage(path, fileMatcher, verbose, goTestArgs)
+	})
 }
 
 // CoverageSingle will generate coverage for the supplied directory (and ignore all sub directories)
-func CoverageSingle(basePath string, verbose bool, goTestArgs []string) {
-	generateCoverage(basePath, verbose, goTestArgs)
+func CoverageSingle(basePath string, fileMatcher *regexp.Regexp, verbose bool, goTestArgs []string) {
+	generateCoverage(basePath, fileMatcher, verbose, goTestArgs)
 }

--- a/package-coverage/main.go
+++ b/package-coverage/main.go
@@ -83,9 +83,9 @@ func main() {
 		buffer := bytes.Buffer{}
 
 		if singleDir {
-			coverageOk = parser.PrintCoverageSingle(&buffer, path, fileExclusions, minCoverage)
+			coverageOk = parser.PrintCoverageSingle(&buffer, path, minCoverage)
 		} else {
-			coverageOk = parser.PrintCoverage(&buffer, path, dirMatcher, fileExclusions, minCoverage)
+			coverageOk = parser.PrintCoverage(&buffer, path, dirMatcher, minCoverage)
 		}
 
 		fmt.Print(buffer.String())
@@ -93,9 +93,9 @@ func main() {
 
 	if slack {
 		if singleDir {
-			parser.SlackCoverageSingle(path, fileExclusions, webHook, prefix, depth)
+			parser.SlackCoverageSingle(path, webHook, prefix, depth)
 		} else {
-			parser.SlackCoverage(path, dirMatcher, fileExclusions, webHook, prefix, depth)
+			parser.SlackCoverage(path, dirMatcher, webHook, prefix, depth)
 		}
 	}
 

--- a/package-coverage/main.go
+++ b/package-coverage/main.go
@@ -53,6 +53,7 @@ func main() {
 
 	startDir := utils.GetCurrentDir()
 	path := getPath()
+	goTestArgs := getGoTestArguments()
 
 	if ignoreDirs != "" {
 		matcher = regexp.MustCompile(ignoreDirs)
@@ -60,9 +61,9 @@ func main() {
 
 	if coverage {
 		if singleDir {
-			generator.CoverageSingle(path)
+			generator.CoverageSingle(path, verbose, goTestArgs)
 		} else {
-			generator.Coverage(path, matcher)
+			generator.Coverage(path, matcher, verbose, goTestArgs)
 		}
 	}
 
@@ -112,4 +113,9 @@ func getPath() string {
 		panic("Please include a directory as the last argument")
 	}
 	return path
+}
+
+func getGoTestArguments() []string {
+	args := flag.Args()
+	return args[1:]
 }

--- a/package-coverage/main.go
+++ b/package-coverage/main.go
@@ -28,11 +28,12 @@ func main() {
 	print := false
 	slack := false
 	ignoreDirs := ""
+	ignoreFiles := ""
 	webHook := ""
 	prefix := ""
 	depth := 0
 	minCoverage := 0
-	var matcher *regexp.Regexp
+	var dirMatcher, fileExclusions *regexp.Regexp
 
 	flag.BoolVar(&verbose, "v", false, "verbose mode")
 	flag.BoolVar(&coverage, "c", false, "generate coverage")
@@ -41,6 +42,7 @@ func main() {
 	flag.BoolVar(&print, "p", false, "print coverage to stdout")
 	flag.BoolVar(&slack, "slack", false, "output coverage to slack")
 	flag.StringVar(&ignoreDirs, "i", `./\.git.*|./_.*`, "ignore regex specified directory")
+	flag.StringVar(&ignoreFiles, "j", `mock.*\.go`, "ignore regex files")
 	flag.StringVar(&webHook, "webhook", "", "Slack webhook URL")
 	flag.StringVar(&prefix, "prefix", "", "Prefix to be removed from the output (currently only supported by Slack output)")
 	flag.IntVar(&depth, "depth", 0, "How many levels of coverage to output (default is 0 = all) (currently only supported by Slack output)")
@@ -56,14 +58,17 @@ func main() {
 	goTestArgs := getGoTestArguments()
 
 	if ignoreDirs != "" {
-		matcher = regexp.MustCompile(ignoreDirs)
+		dirMatcher = regexp.MustCompile(ignoreDirs)
+	}
+	if ignoreFiles != "" {
+		fileExclusions = regexp.MustCompile(ignoreFiles)
 	}
 
 	if coverage {
 		if singleDir {
-			generator.CoverageSingle(path, verbose, goTestArgs)
+			generator.CoverageSingle(path, fileExclusions, verbose, goTestArgs)
 		} else {
-			generator.Coverage(path, matcher, verbose, goTestArgs)
+			generator.Coverage(path, dirMatcher, fileExclusions, verbose, goTestArgs)
 		}
 	}
 
@@ -78,9 +83,9 @@ func main() {
 		buffer := bytes.Buffer{}
 
 		if singleDir {
-			coverageOk = parser.PrintCoverageSingle(&buffer, path, minCoverage)
+			coverageOk = parser.PrintCoverageSingle(&buffer, path, fileExclusions, minCoverage)
 		} else {
-			coverageOk = parser.PrintCoverage(&buffer, path, matcher, minCoverage)
+			coverageOk = parser.PrintCoverage(&buffer, path, dirMatcher, fileExclusions, minCoverage)
 		}
 
 		fmt.Print(buffer.String())
@@ -88,9 +93,9 @@ func main() {
 
 	if slack {
 		if singleDir {
-			parser.SlackCoverageSingle(path, webHook, prefix, depth)
+			parser.SlackCoverageSingle(path, fileExclusions, webHook, prefix, depth)
 		} else {
-			parser.SlackCoverage(path, matcher, webHook, prefix, depth)
+			parser.SlackCoverage(path, dirMatcher, fileExclusions, webHook, prefix, depth)
 		}
 	}
 
@@ -98,7 +103,7 @@ func main() {
 		if singleDir {
 			generator.CleanSingle(path)
 		} else {
-			generator.Clean(path, matcher)
+			generator.Clean(path, dirMatcher)
 		}
 	}
 

--- a/package-coverage/main.go
+++ b/package-coverage/main.go
@@ -117,5 +117,12 @@ func getPath() string {
 
 func getGoTestArguments() []string {
 	args := flag.Args()
-	return args[1:]
+
+	// We only assume what comes after -- to be `go test` arguments. If there are two arguments, we do not assume them
+	// to be `go test` arguments.
+	if (len(args) >= 2 && args[1] != "--") || len(args) < 3 {
+		return []string{}
+	}
+
+	return args[2:]
 }

--- a/package-coverage/parser/coverage.go
+++ b/package-coverage/parser/coverage.go
@@ -8,31 +8,31 @@ import (
 )
 
 // get coverage using the paths and exclusions supplied
-func getCoverageData(paths []string, matcher *regexp.Regexp) ([]string, coverageByPackage) {
+func getCoverageData(paths []string, dirMatcher, fileMatcher *regexp.Regexp) ([]string, coverageByPackage) {
 	var contents string
 	for _, path := range paths {
-		if matcher.FindString(path) != "" {
-			log.Printf("Printing of coverage for path '%s' skipped due to skipDir regex '%s'", path, matcher.String())
+		if dirMatcher.FindString(path) != "" {
+			log.Printf("Printing of coverage for path '%s' skipped due to skipDir regex '%s'", path, dirMatcher.String())
 			continue
 		}
 
 		contents += getFileContents(path)
 	}
 
-	return getCoverageByContents(contents)
+	return getCoverageByContents(contents, fileMatcher)
 }
 
 // get coverage from supplied string (used after concatenating all the individual coverage files together
-func getCoverageByContents(contents string) ([]string, coverageByPackage) {
-	coverageData := getCoverageByPackage(contents)
+func getCoverageByContents(contents string, fileMatcher *regexp.Regexp) ([]string, coverageByPackage) {
+	coverageData := getCoverageByPackage(contents, fileMatcher)
 	pkgs := getSortedPackages(coverageData)
 
 	return pkgs, coverageData
 }
 
 // will calculate and return the coverage for a package or packages from the supplied coverage file contents
-func getCoverageByPackage(contents string) coverageByPackage {
-	coverageData := parseLines(contents)
+func getCoverageByPackage(contents string, fileMatcher *regexp.Regexp) coverageByPackage {
+	coverageData := parseLines(contents, fileMatcher)
 	return coverageData
 }
 

--- a/package-coverage/parser/coverage.go
+++ b/package-coverage/parser/coverage.go
@@ -8,7 +8,7 @@ import (
 )
 
 // get coverage using the paths and exclusions supplied
-func getCoverageData(paths []string, dirMatcher, fileMatcher *regexp.Regexp) ([]string, coverageByPackage) {
+func getCoverageData(paths []string, dirMatcher *regexp.Regexp) ([]string, coverageByPackage) {
 	var contents string
 	for _, path := range paths {
 		if dirMatcher.FindString(path) != "" {
@@ -19,20 +19,20 @@ func getCoverageData(paths []string, dirMatcher, fileMatcher *regexp.Regexp) ([]
 		contents += getFileContents(path)
 	}
 
-	return getCoverageByContents(contents, fileMatcher)
+	return getCoverageByContents(contents)
 }
 
 // get coverage from supplied string (used after concatenating all the individual coverage files together
-func getCoverageByContents(contents string, fileMatcher *regexp.Regexp) ([]string, coverageByPackage) {
-	coverageData := getCoverageByPackage(contents, fileMatcher)
+func getCoverageByContents(contents string) ([]string, coverageByPackage) {
+	coverageData := getCoverageByPackage(contents)
 	pkgs := getSortedPackages(coverageData)
 
 	return pkgs, coverageData
 }
 
 // will calculate and return the coverage for a package or packages from the supplied coverage file contents
-func getCoverageByPackage(contents string, fileMatcher *regexp.Regexp) coverageByPackage {
-	coverageData := parseLines(contents, fileMatcher)
+func getCoverageByPackage(contents string) coverageByPackage {
+	coverageData := parseLines(contents)
 	return coverageData
 }
 

--- a/package-coverage/parser/file_parser.go
+++ b/package-coverage/parser/file_parser.go
@@ -20,7 +20,7 @@ type coverage struct {
 }
 
 // convert string contents of the coverage files into data structures
-func parseLines(raw string, fileExclusions *regexp.Regexp) map[string]*coverage {
+func parseLines(raw string) map[string]*coverage {
 	output := make(map[string]*coverage)
 
 	lines := strings.Split(raw, "\n")
@@ -30,7 +30,7 @@ func parseLines(raw string, fileExclusions *regexp.Regexp) map[string]*coverage 
 	}
 
 	fragmentCh := make(chan fragment, len(lines))
-	doneCh := processFragments(output, fragmentCh, fileExclusions)
+	doneCh := processFragments(output, fragmentCh)
 
 	for _, line := range lines {
 		if !validLineFormat(line) {
@@ -53,14 +53,11 @@ func validLineFormat(line string) bool {
 	return lineFormatChecker.MatchString(line)
 }
 
-func processFragments(output map[string]*coverage, fragmentCh chan fragment, fileExclusions *regexp.Regexp) chan struct{} {
+func processFragments(output map[string]*coverage, fragmentCh chan fragment) chan struct{} {
 	doneCh := make(chan struct{})
 
 	go func() {
 		for fragment := range fragmentCh {
-			if fileExclusions != nil && fileExclusions.MatchString(fragment.file) {
-				continue
-			}
 			coverage := getOrCreateCoverage(output, fragment.pkg)
 			processSelfCoverage(coverage, fragment)
 		}

--- a/package-coverage/parser/file_parser.go
+++ b/package-coverage/parser/file_parser.go
@@ -20,7 +20,7 @@ type coverage struct {
 }
 
 // convert string contents of the coverage files into data structures
-func parseLines(raw string) map[string]*coverage {
+func parseLines(raw string, fileExclusions *regexp.Regexp) map[string]*coverage {
 	output := make(map[string]*coverage)
 
 	lines := strings.Split(raw, "\n")
@@ -30,7 +30,7 @@ func parseLines(raw string) map[string]*coverage {
 	}
 
 	fragmentCh := make(chan fragment, len(lines))
-	doneCh := processFragments(output, fragmentCh)
+	doneCh := processFragments(output, fragmentCh, fileExclusions)
 
 	for _, line := range lines {
 		if !validLineFormat(line) {
@@ -53,11 +53,14 @@ func validLineFormat(line string) bool {
 	return lineFormatChecker.MatchString(line)
 }
 
-func processFragments(output map[string]*coverage, fragmentCh chan fragment) chan struct{} {
+func processFragments(output map[string]*coverage, fragmentCh chan fragment, fileExclusions *regexp.Regexp) chan struct{} {
 	doneCh := make(chan struct{})
 
 	go func() {
 		for fragment := range fragmentCh {
+			if fileExclusions != nil && fileExclusions.MatchString(fragment.file) {
+				continue
+			}
 			coverage := getOrCreateCoverage(output, fragment.pkg)
 			processSelfCoverage(coverage, fragment)
 		}

--- a/package-coverage/parser/line_parser.go
+++ b/package-coverage/parser/line_parser.go
@@ -8,13 +8,15 @@ import (
 
 type fragment struct {
 	pkg        string
+	file       string
 	statements int
 	covered    bool
 }
 
 func parseLine(raw string) fragment {
 	output := fragment{
-		pkg: extractPackage(raw),
+		pkg:  extractPackage(raw),
+		file: extractFile(raw),
 	}
 
 	output.statements, output.covered = extractNumbers(raw)
@@ -29,6 +31,21 @@ func extractPackage(raw string) string {
 	}
 
 	return raw[:(lastSlash + 1)]
+}
+
+func extractFile(raw string) string {
+	lastSlash := strings.LastIndex(raw, "/")
+	if lastSlash == -1 {
+		panic(fmt.Errorf("line skipped due to lack of package '%s'", raw))
+	}
+
+	fileAndLines := raw[(lastSlash + 1):]
+	line := strings.LastIndex(fileAndLines, ":")
+	if line == -1 {
+		panic(fmt.Errorf("line skipped due to lack of line number '%s'", raw))
+	}
+
+	return fileAndLines[:line]
 }
 
 func extractNumbers(raw string) (int, bool) {

--- a/package-coverage/parser/print_coverage.go
+++ b/package-coverage/parser/print_coverage.go
@@ -13,18 +13,18 @@ import (
 type coverageByPackage map[string]*coverage
 
 // PrintCoverage will attempt to calculate and print the coverage from the supplied coverage file to standard out.
-func PrintCoverage(writer io.Writer, basePath string, dirMatcher, fileMatcher *regexp.Regexp, minCoverage int) bool {
+func PrintCoverage(writer io.Writer, basePath string, dirMatcher *regexp.Regexp, minCoverage int) bool {
 	paths, err := utils.FindAllCoverageFiles(basePath)
 	if err != nil {
 		log.Panicf("error file finding coverage files %s", err)
 	}
 
-	pkgs, coverageData := getCoverageData(paths, dirMatcher, fileMatcher)
+	pkgs, coverageData := getCoverageData(paths, dirMatcher)
 	return printCoverage(writer, pkgs, coverageData, float64(minCoverage))
 }
 
 // PrintCoverageSingle is the same as PrintCoverage only for 1 directory only
-func PrintCoverageSingle(writer io.Writer, path string, fileMatcher *regexp.Regexp, minCoverage int) bool {
+func PrintCoverageSingle(writer io.Writer, path string, minCoverage int) bool {
 	var fullPath string
 	if path == "./" {
 		fullPath = utils.GetCurrentDir()
@@ -34,7 +34,7 @@ func PrintCoverageSingle(writer io.Writer, path string, fileMatcher *regexp.Rege
 	fullPath += "profile.cov"
 
 	contents := getFileContents(fullPath)
-	pkgs, coverageData := getCoverageByContents(contents, fileMatcher)
+	pkgs, coverageData := getCoverageByContents(contents)
 
 	return printCoverage(writer, pkgs, coverageData, float64(minCoverage))
 }

--- a/package-coverage/parser/print_coverage.go
+++ b/package-coverage/parser/print_coverage.go
@@ -13,18 +13,18 @@ import (
 type coverageByPackage map[string]*coverage
 
 // PrintCoverage will attempt to calculate and print the coverage from the supplied coverage file to standard out.
-func PrintCoverage(writer io.Writer, basePath string, matcher *regexp.Regexp, minCoverage int) bool {
+func PrintCoverage(writer io.Writer, basePath string, dirMatcher, fileMatcher *regexp.Regexp, minCoverage int) bool {
 	paths, err := utils.FindAllCoverageFiles(basePath)
 	if err != nil {
 		log.Panicf("error file finding coverage files %s", err)
 	}
 
-	pkgs, coverageData := getCoverageData(paths, matcher)
+	pkgs, coverageData := getCoverageData(paths, dirMatcher, fileMatcher)
 	return printCoverage(writer, pkgs, coverageData, float64(minCoverage))
 }
 
 // PrintCoverageSingle is the same as PrintCoverage only for 1 directory only
-func PrintCoverageSingle(writer io.Writer, path string, minCoverage int) bool {
+func PrintCoverageSingle(writer io.Writer, path string, fileMatcher *regexp.Regexp, minCoverage int) bool {
 	var fullPath string
 	if path == "./" {
 		fullPath = utils.GetCurrentDir()
@@ -34,7 +34,7 @@ func PrintCoverageSingle(writer io.Writer, path string, minCoverage int) bool {
 	fullPath += "profile.cov"
 
 	contents := getFileContents(fullPath)
-	pkgs, coverageData := getCoverageByContents(contents)
+	pkgs, coverageData := getCoverageByContents(contents, fileMatcher)
 
 	return printCoverage(writer, pkgs, coverageData, float64(minCoverage))
 }

--- a/package-coverage/parser/slack_coverage.go
+++ b/package-coverage/parser/slack_coverage.go
@@ -16,18 +16,18 @@ import (
 )
 
 // SlackCoverage will attempt to calculate and output the coverage from the supplied coverage files to Slack
-func SlackCoverage(basePath string, dirMatcher, fileMatcher *regexp.Regexp, webHook string, prefix string, depth int) {
+func SlackCoverage(basePath string, dirMatcher *regexp.Regexp, webHook string, prefix string, depth int) {
 	paths, err := utils.FindAllCoverageFiles(basePath)
 	if err != nil {
 		log.Panicf("error file finding coverage files %s", err)
 	}
 
-	pkgs, coverageData := getCoverageData(paths, dirMatcher, fileMatcher)
+	pkgs, coverageData := getCoverageData(paths, dirMatcher)
 	prepareAndSendToSlack(pkgs, coverageData, webHook, prefix, depth)
 }
 
 // SlackCoverageSingle is the same as SlackCoverage only for 1 directory only
-func SlackCoverageSingle(path string, fileExclusions *regexp.Regexp, webHook string, prefix string, depth int) {
+func SlackCoverageSingle(path string, webHook string, prefix string, depth int) {
 	var fullPath string
 	if path == "./" {
 		fullPath = utils.GetCurrentDir()
@@ -37,7 +37,7 @@ func SlackCoverageSingle(path string, fileExclusions *regexp.Regexp, webHook str
 	fullPath += "profile.cov"
 
 	contents := getFileContents(fullPath)
-	pkgs, coverageData := getCoverageByContents(contents, fileExclusions)
+	pkgs, coverageData := getCoverageByContents(contents)
 
 	prepareAndSendToSlack(pkgs, coverageData, webHook, prefix, depth)
 }

--- a/package-coverage/parser/slack_coverage.go
+++ b/package-coverage/parser/slack_coverage.go
@@ -16,18 +16,18 @@ import (
 )
 
 // SlackCoverage will attempt to calculate and output the coverage from the supplied coverage files to Slack
-func SlackCoverage(basePath string, matcher *regexp.Regexp, webHook string, prefix string, depth int) {
+func SlackCoverage(basePath string, dirMatcher, fileMatcher *regexp.Regexp, webHook string, prefix string, depth int) {
 	paths, err := utils.FindAllCoverageFiles(basePath)
 	if err != nil {
 		log.Panicf("error file finding coverage files %s", err)
 	}
 
-	pkgs, coverageData := getCoverageData(paths, matcher)
+	pkgs, coverageData := getCoverageData(paths, dirMatcher, fileMatcher)
 	prepareAndSendToSlack(pkgs, coverageData, webHook, prefix, depth)
 }
 
 // SlackCoverageSingle is the same as SlackCoverage only for 1 directory only
-func SlackCoverageSingle(path string, webHook string, prefix string, depth int) {
+func SlackCoverageSingle(path string, fileExclusions *regexp.Regexp, webHook string, prefix string, depth int) {
 	var fullPath string
 	if path == "./" {
 		fullPath = utils.GetCurrentDir()
@@ -37,7 +37,7 @@ func SlackCoverageSingle(path string, webHook string, prefix string, depth int) 
 	fullPath += "profile.cov"
 
 	contents := getFileContents(fullPath)
-	pkgs, coverageData := getCoverageByContents(contents)
+	pkgs, coverageData := getCoverageByContents(contents, fileExclusions)
 
 	prepareAndSendToSlack(pkgs, coverageData, webHook, prefix, depth)
 }


### PR DESCRIPTION
Depends on #9.

The `-j` flag will specify a regex which will be matched against each fragment in a coverage report. If the line matches the regex, the line will be dropped.

This allows generated files in a package to be ignored from the computed coverage.

By default, `mock.*\.go` is ignored.