### PR TITLE
Merge the package and file exclusions matchers

### DIFF
--- a/package-coverage/README.md
+++ b/package-coverage/README.md
@@ -8,7 +8,7 @@ This tool intents to calculate the test coverage of a particular package (includ
 * `$ package-coverage -v` is useful for debugging as it will print to std out a trace of what it is doing
 * `$ package-coverage -s` will switch this tool into "single directory" mode (will not recurse down the file tree)
 * `$ package-coverage -webhook=https://hooks.slack.com/services/fu/bar` will print the coverage information to Slack using the supplied webbook
-* `$ package-coverage -i="_generated/"` defines a regex of directories that should be excluded from coverage (useful for generated code)
+* `$ package-coverage -i="/_generated/|/z_.*"` defines a regex of paths that should be excluded from coverage (useful for generated code). Match directories by surrounding with slashes; match files by prefixing with a slash.
 * `$ package-coverage -p -prefix="github.com/corsc/"` this string will removed from the front of any outputted package names (current only supported by the slack output)
 * `$ package-coverage -slack -depth=1` how many levels to output.  This does not effect the calculation only the output. (current only supported by the slack output)
 * `$ package-coverage -p -m=1` will highlight (in red) the console output of any packages below the supplied number (current only supported console output)

--- a/package-coverage/generator/clean.go
+++ b/package-coverage/generator/clean.go
@@ -10,8 +10,8 @@ import (
 
 // Clean will search the supplied directory and any sub-directories that contain Go files and remove any
 // existing coverage files
-func Clean(basePath string, matcher *regexp.Regexp) {
-	processAllDirs(basePath, matcher, "clean", clean)
+func Clean(basePath string, exclusionsMatcher *regexp.Regexp) {
+	processAllDirs(basePath, exclusionsMatcher, "clean", clean)
 }
 
 // CleanSingle will search the supplied directory that contain Go files and remove any existing coverage file

--- a/package-coverage/generator/generator.go
+++ b/package-coverage/generator/generator.go
@@ -6,13 +6,13 @@ import "regexp"
 const UnknownPackage = "unknown"
 
 // Coverage will generate coverage for the supplied directory and any sub-directories that contain Go files
-func Coverage(basePath string, dirMatcher, fileMatcher *regexp.Regexp, goTestArgs []string) {
-	processAllDirs(basePath, dirMatcher, "coverage", func(path string) {
-		generateCoverage(path, fileMatcher, goTestArgs)
+func Coverage(basePath string, exclusionsMatcher *regexp.Regexp, goTestArgs []string) {
+	processAllDirs(basePath, exclusionsMatcher, "coverage", func(path string) {
+		generateCoverage(path, exclusionsMatcher, goTestArgs)
 	})
 }
 
 // CoverageSingle will generate coverage for the supplied directory (and ignore all sub directories)
-func CoverageSingle(basePath string, fileMatcher *regexp.Regexp, goTestArgs []string) {
-	generateCoverage(basePath, fileMatcher, goTestArgs)
+func CoverageSingle(basePath string, exclusionsMatcher *regexp.Regexp, goTestArgs []string) {
+	generateCoverage(basePath, exclusionsMatcher, goTestArgs)
 }

--- a/package-coverage/main.go
+++ b/package-coverage/main.go
@@ -36,7 +36,7 @@ func main() {
 	flag.BoolVar(&singleDir, "s", false, "only generate for the supplied directory (no recursion / will ignore -i)")
 	flag.BoolVar(&clean, "d", false, "clean")
 	flag.BoolVar(&print, "p", false, "print coverage to stdout")
-	flag.StringVar(&ignorePaths, "i", `./\.git.*|./_.*`, "ignore file paths matching the specified regex (match directories by surrounding the directory name with slashes)")
+	flag.StringVar(&ignorePaths, "i", `./\.git.*|./_.*`, "ignore file paths matching the specified regex (match directories by surrounding the directory name with slashes; match files by prefixing with a slash)")
 	flag.StringVar(&webHook, "webhook", "", "Slack webhook URL (missing means don't send)")
 	flag.StringVar(&prefix, "prefix", "", "Prefix to be removed from the output (currently only supported by Slack output)")
 	flag.IntVar(&depth, "depth", 0, "How many levels of coverage to output (default is 0 = all) (currently only supported by Slack output)")

--- a/package-coverage/parser/coverage.go
+++ b/package-coverage/parser/coverage.go
@@ -8,11 +8,12 @@ import (
 )
 
 // get coverage using the paths and exclusions supplied
-func getCoverageData(paths []string, dirMatcher *regexp.Regexp) ([]string, coverageByPackage) {
+func getCoverageData(paths []string, exclusionsMatcher *regexp.Regexp) ([]string, coverageByPackage) {
 	var contents string
 	for _, path := range paths {
-		if dirMatcher.FindString(path) != "" {
-			log.Printf("Printing of coverage for path '%s' skipped due to skipDir regex '%s'", path, dirMatcher.String())
+		if exclusionsMatcher.FindString(path) != "" {
+			log.Printf("Printing of coverage for path '%s' skipped due to exclusions regex '%s'",
+				path, exclusionsMatcher.String())
 			continue
 		}
 

--- a/package-coverage/parser/print_coverage.go
+++ b/package-coverage/parser/print_coverage.go
@@ -13,13 +13,13 @@ import (
 type coverageByPackage map[string]*coverage
 
 // PrintCoverage will attempt to calculate and print the coverage from the supplied coverage file to standard out.
-func PrintCoverage(writer io.Writer, basePath string, dirMatcher *regexp.Regexp, minCoverage int) bool {
+func PrintCoverage(writer io.Writer, basePath string, exclusionsMatcher *regexp.Regexp, minCoverage int) bool {
 	paths, err := utils.FindAllCoverageFiles(basePath)
 	if err != nil {
 		log.Panicf("error file finding coverage files %s", err)
 	}
 
-	pkgs, coverageData := getCoverageData(paths, dirMatcher)
+	pkgs, coverageData := getCoverageData(paths, exclusionsMatcher)
 	return printCoverage(writer, pkgs, coverageData, float64(minCoverage))
 }
 

--- a/package-coverage/parser/slack_coverage.go
+++ b/package-coverage/parser/slack_coverage.go
@@ -13,13 +13,13 @@ import (
 )
 
 // SlackCoverage will attempt to calculate and output the coverage from the supplied coverage files to Slack
-func SlackCoverage(basePath string, dirMatcher *regexp.Regexp, webHook string, prefix string, depth int) {
+func SlackCoverage(basePath string, exclusionsMatcher *regexp.Regexp, webHook string, prefix string, depth int) {
 	paths, err := utils.FindAllCoverageFiles(basePath)
 	if err != nil {
 		log.Panicf("error file finding coverage files %s", err)
 	}
 
-	pkgs, coverageData := getCoverageData(paths, dirMatcher)
+	pkgs, coverageData := getCoverageData(paths, exclusionsMatcher)
 	prepareAndSendToSlack(pkgs, coverageData, webHook, prefix, depth)
 }
 

--- a/package-coverage/tests/fixtures/path_matcher/excluded/file_excluded.go
+++ b/package-coverage/tests/fixtures/path_matcher/excluded/file_excluded.go
@@ -1,0 +1,1 @@
+package excluded

--- a/package-coverage/tests/fixtures/path_matcher/included/file_included.go
+++ b/package-coverage/tests/fixtures/path_matcher/included/file_included.go
@@ -1,0 +1,1 @@
+package included

--- a/package-coverage/tests/fixtures/path_matcher/path_matcher.go
+++ b/package-coverage/tests/fixtures/path_matcher/path_matcher.go
@@ -1,0 +1,1 @@
+package path_matcher

--- a/package-coverage/utils/directories.go
+++ b/package-coverage/utils/directories.go
@@ -28,10 +28,13 @@ func FindAllCoverageFiles(basePath string) ([]string, error) {
 func finder(basePath string, searchFor mode) ([]string, error) {
 	found := []string{}
 
+	oldCurrentDirectory := GetCurrentDir()
 	err := os.Chdir(basePath)
 	if err != nil {
 		return nil, err
 	}
+
+	defer os.Chdir(oldCurrentDirectory)
 
 	_ = filepath.Walk("./", func(path string, finfo os.FileInfo, err error) error {
 		if err != nil {

--- a/package-coverage/utils/directories_test.go
+++ b/package-coverage/utils/directories_test.go
@@ -15,10 +15,15 @@ func TestFindAllGoDirs(t *testing.T) {
 		dir + "package-coverage/",
 		dir + "package-coverage/generator/",
 		dir + "package-coverage/parser/",
+		dir + "package-coverage/tests/fixtures/path_matcher/",
+		dir + "package-coverage/tests/fixtures/path_matcher/excluded/",
+		dir + "package-coverage/tests/fixtures/path_matcher/included/",
 		dir + "package-coverage/utils/",
 	}
 
+	currentDir := GetCurrentDir()
 	results, err := FindAllGoDirs(path)
+	assert.Equal(t, currentDir, GetCurrentDir(), "expected current working directory to be restored")
 
 	assert.Nil(t, err)
 	assert.Equal(t, expected, results)


### PR DESCRIPTION
This unifies the package and file exclusions matchers. To match
directories, surround the directory name with slashes: `/dirname/`. To
match files, prefix the filename with a slash: `/something.go`.