### PR TITLE
Fix delete and Suppress 'go test' output by default

### DIFF
--- a/gonerator/tmpl/methods.go
+++ b/gonerator/tmpl/methods.go
@@ -62,34 +62,28 @@ func GetMethods(file *ast.File, typeName string) []Method {
 }
 
 func extractParamsAndResults(fnDesl *ast.FuncType) ([]MethodField, []MethodField) {
-	params := []MethodField{}
-	results := []MethodField{}
-
-	for _, param := range fnDesl.Params.List {
-		typeStr := getTypeString(param.Type)
-		funcField := MethodField{
-			Type:  typeStr,
-			Names: make([]string, len(param.Names)),
-		}
-		for i := 0; i < len(param.Names); i++ {
-			funcField.Names[i] = param.Names[i].Name
-		}
-		params = append(params, funcField)
-	}
-
-	for _, result := range fnDesl.Results.List {
-		typeStr := getTypeString(result.Type)
-		funcResult := MethodField{
-			Type:  typeStr,
-			Names: make([]string, len(result.Names)),
-		}
-		for i := 0; i < len(result.Names); i++ {
-			funcResult.Names[i] = result.Names[i].Name
-		}
-		results = append(results, funcResult)
-	}
+	params := extractFieldsFromAst(fnDesl.Params.List)
+	results := extractFieldsFromAst(fnDesl.Results.List)
 
 	return params, results
+}
+
+func extractFieldsFromAst(items []*ast.Field) []MethodField {
+	output := []MethodField{}
+
+	for _, item := range items {
+		typeStr := getTypeString(item.Type)
+		funcField := MethodField{
+			Type:  typeStr,
+			Names: make([]string, len(item.Names)),
+		}
+		for i := 0; i < len(item.Names); i++ {
+			funcField.Names[i] = item.Names[i].Name
+		}
+		output = append(output, funcField)
+	}
+
+	return output
 }
 
 func getTypeString(expr ast.Expr) string {

--- a/package-coverage/README.md
+++ b/package-coverage/README.md
@@ -3,6 +3,7 @@ This tool intents to calculate the test coverage of a particular package (includ
 ## Command line options:
 
 * `$ package-coverage -c ./` will generate coverage.  1 coverage file (*.cov) per package
+* `$ package-coverage -c -q=false ./` generate coverage and also output os.Stdout and os.Stderr from "go test"
 * `$ package-coverage -d ./` will remove any previous coverage files (will remove all *.cov files)
 * `$ package-coverage -p ./` will import all coverage files under the supplied dir and output the summary.
 * `$ package-coverage -v` is useful for debugging as it will print to std out a trace of what it is doing

--- a/package-coverage/generator/clean.go
+++ b/package-coverage/generator/clean.go
@@ -1,37 +1,76 @@
 package generator
 
 import (
-	"log"
 	"os"
 	"regexp"
 
 	"github.com/corsc/go-tools/package-coverage/utils"
 )
 
+// NewCleaner returns an instance of the default Cleaner implmentation
+func NewCleaner() Cleaner {
+	return &cleanerImpl{
+		fsWrapper: &fsWrapperImpl{},
+	}
+}
+
+// Cleaner will remove any previously generated coverage files
+type Cleaner interface {
+	// Clean a single directory
+	Single(path string)
+
+	// Recursive will clean a directory and all child directories (excluding any matched be the regex)
+	Recursive(path string, exclusions *regexp.Regexp)
+}
+
+// default implementation of the Cleaner interface
+type cleanerImpl struct {
+	fsWrapper fsWrapper
+}
+
+// Single implements the Cleaner interface
+func (cleaner *cleanerImpl) Single(path string) {
+	cleaner.clean(path)
+}
+
 // Clean will search the supplied directory and any sub-directories that contain Go files and remove any
 // existing coverage files
-func Clean(basePath string, exclusionsMatcher *regexp.Regexp) {
-	processAllDirs(basePath, exclusionsMatcher, "clean", clean)
+func (cleaner *cleanerImpl) Recursive(path string, exclusions *regexp.Regexp) {
+	processAllDirs(path, exclusions, "clean", cleaner.clean)
 }
 
-// CleanSingle will search the supplied directory that contain Go files and remove any existing coverage file
-func CleanSingle(path string) {
-	clean(path)
-}
-
-func clean(path string) {
+func (cleaner *cleanerImpl) clean(path string) {
 	coverageFile := path + coverageFilename
-	removeCoverageFile(coverageFile)
+
+	if cleaner.fsWrapper.Exists(coverageFile) {
+		utils.LogWhenVerbose("[cleaner] removing coverage file @ %s", coverageFile)
+		cleaner.fsWrapper.Delete(coverageFile)
+	}
 }
 
-// remove the previously created coverage file
-func removeCoverageFile(filename string) {
-	if _, err := os.Stat(filename); err == nil {
-		utils.LogWhenVerbose("removing coverage file @ %s", filename)
+type fsWrapper interface {
+	// Returns true if a file exists and false otherwise
+	Exists(filename string) bool
 
-		err := os.Remove(filename)
-		if err != nil {
-			log.Printf("error while removing test file @ %s, err: %s", filename, err)
-		}
+	// Remove a file
+	Delete(filename string)
+}
+
+// default implementation of fsWrapper
+type fsWrapperImpl struct{}
+
+// Exists implements fsWrapper
+func (fs *fsWrapperImpl) Exists(filename string) bool {
+	if _, err := os.Stat(filename); err == nil {
+		return true
+	}
+	return false
+}
+
+// Delete implements fsWrapper
+func (fs *fsWrapperImpl) Delete(filename string) {
+	err := os.Remove(filename)
+	if err != nil {
+		utils.LogWhenVerbose("[cleaner] failed to remove %s with err: %s", filename, err)
 	}
 }

--- a/package-coverage/generator/clean_test.go
+++ b/package-coverage/generator/clean_test.go
@@ -1,0 +1,63 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCleanerImpl_Single(t *testing.T) {
+	path := "./test/"
+
+	scenarios := []struct {
+		desc      string
+		setupMock func(mockFs *mockFsWrapper)
+	}{
+		{
+			desc: "file exists, delete should be called",
+			setupMock: func(mockFs *mockFsWrapper) {
+				mockFs.On("Exists", path+coverageFilename).Once().Return(true)
+				mockFs.On("Delete", path+coverageFilename).Once()
+			},
+		},
+		{
+			desc: "file does not exist, delete should not be called",
+			setupMock: func(mockFs *mockFsWrapper) {
+				mockFs.On("Exists", path+coverageFilename).Once().Return(false)
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		cleaner, mockFs := newTestCleaner()
+		scenario.setupMock(mockFs)
+
+		cleaner.Single(path)
+		assert.True(t, mockFs.AssertExpectations(t), scenario.desc)
+	}
+}
+
+func newTestCleaner() (Cleaner, *mockFsWrapper) {
+	mockFs := &mockFsWrapper{}
+
+	return &cleanerImpl{
+		fsWrapper: mockFs,
+	}, mockFs
+}
+
+// mock implementation of the fsWrapper
+type mockFsWrapper struct {
+	mock.Mock
+}
+
+// Exists implements fsWrapper
+func (fs *mockFsWrapper) Exists(filename string) bool {
+	outputs := fs.Mock.Called(filename)
+	return outputs.Bool(0)
+}
+
+// Delete implements fsWrapper
+func (fs *mockFsWrapper) Delete(filename string) {
+	fs.Mock.Called(filename)
+}

--- a/package-coverage/generator/coverage.go
+++ b/package-coverage/generator/coverage.go
@@ -151,7 +151,7 @@ func execCoverage(dir, coverageFilename string, quiet bool, goTestArgs []string)
 	utils.LogWhenVerbose("[coverage] created coverage file @ %s%s", dir, coverageFilename)
 
 	if !quiet {
-		utils.LogWhenVerbose("[coverage] go test output: \n %s", out)
+		print(string(out))
 	}
 
 	return nil

--- a/package-coverage/generator/coverage.go
+++ b/package-coverage/generator/coverage.go
@@ -142,17 +142,18 @@ func execCoverage(dir, coverageFilename string, quiet bool, goTestArgs []string)
 	cmd := exec.Command(command, arguments...)
 	cmd.Dir = dir
 
-	out, err := cmd.Output()
+	if !quiet {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+
+	err := cmd.Run()
 	if err != nil {
 		utils.LogWhenVerbose("[coverage] error while running go test. err: %s", err)
 		return err
 	}
 
 	utils.LogWhenVerbose("[coverage] created coverage file @ %s%s", dir, coverageFilename)
-
-	if !quiet {
-		print(string(out))
-	}
 
 	return nil
 }

--- a/package-coverage/generator/coverage_test.go
+++ b/package-coverage/generator/coverage_test.go
@@ -2,12 +2,13 @@ package generator
 
 import (
 	"io/ioutil"
-	"log"
 	"os"
 	"regexp"
 	"sort"
 	"strings"
 	"testing"
+
+	"log"
 
 	"github.com/corsc/go-tools/package-coverage/utils"
 	"github.com/stretchr/testify/assert"
@@ -106,7 +107,7 @@ func TestRemoveFakeTest(t *testing.T) {
 func removeTestFile(path string) {
 	err := os.Remove(path)
 	if err != nil {
-		log.Printf("error while removing test file %s", err)
+		log.Panicf("error while removing test file %s", err)
 	}
 }
 

--- a/package-coverage/generator/generator.go
+++ b/package-coverage/generator/generator.go
@@ -6,13 +6,13 @@ import "regexp"
 const UnknownPackage = "unknown"
 
 // Coverage will generate coverage for the supplied directory and any sub-directories that contain Go files
-func Coverage(basePath string, exclusionsMatcher *regexp.Regexp, goTestArgs []string) {
+func Coverage(basePath string, exclusionsMatcher *regexp.Regexp, quiet bool, goTestArgs []string) {
 	processAllDirs(basePath, exclusionsMatcher, "coverage", func(path string) {
-		generateCoverage(path, exclusionsMatcher, goTestArgs)
+		generateCoverage(path, exclusionsMatcher, quiet, goTestArgs)
 	})
 }
 
 // CoverageSingle will generate coverage for the supplied directory (and ignore all sub directories)
-func CoverageSingle(basePath string, exclusionsMatcher *regexp.Regexp, goTestArgs []string) {
-	generateCoverage(basePath, exclusionsMatcher, goTestArgs)
+func CoverageSingle(basePath string, exclusionsMatcher *regexp.Regexp, quiet bool, goTestArgs []string) {
+	generateCoverage(basePath, exclusionsMatcher, quiet, goTestArgs)
 }

--- a/package-coverage/main.go
+++ b/package-coverage/main.go
@@ -33,7 +33,7 @@ func main() {
 	var exclusions *regexp.Regexp
 
 	flag.BoolVar(&verbose, "v", false, "verbose mode is useful for debugging this tool")
-	flag.BoolVar(&quiet, "n", true, "quiet mode will supress the stdOut messages from go test")
+	flag.BoolVar(&quiet, "q", true, "quiet mode will supress the stdOut messages from go test")
 	flag.BoolVar(&coverage, "c", false, "generate coverage")
 	flag.BoolVar(&singleDir, "s", false, "only generate for the supplied directory (no recursion / will ignore -i)")
 	flag.BoolVar(&clean, "d", false, "clean")

--- a/package-coverage/parser/coverage.go
+++ b/package-coverage/parser/coverage.go
@@ -2,9 +2,10 @@ package parser
 
 import (
 	"io/ioutil"
-	"log"
 	"regexp"
 	"sort"
+
+	"github.com/corsc/go-tools/package-coverage/utils"
 )
 
 // get coverage using the paths and exclusions supplied
@@ -12,7 +13,7 @@ func getCoverageData(paths []string, exclusionsMatcher *regexp.Regexp) ([]string
 	var contents string
 	for _, path := range paths {
 		if exclusionsMatcher.FindString(path) != "" {
-			log.Printf("Printing of coverage for path '%s' skipped due to exclusions regex '%s'",
+			utils.LogWhenVerbose("[print] Printing of coverage for path '%s' skipped due to exclusions regex '%s'",
 				path, exclusionsMatcher.String())
 			continue
 		}

--- a/package-coverage/parser/file_parser.go
+++ b/package-coverage/parser/file_parser.go
@@ -1,9 +1,10 @@
 package parser
 
 import (
-	"log"
 	"regexp"
 	"strings"
+
+	"github.com/corsc/go-tools/package-coverage/utils"
 )
 
 // coverage data line format (used to filter out the rest of the coverage file contents)
@@ -25,7 +26,7 @@ func parseLines(raw string) map[string]*coverage {
 
 	lines := strings.Split(raw, "\n")
 	if len(lines) == 0 {
-		log.Print("no lines found in the supplied file")
+		utils.LogWhenVerbose("[print] no lines found in the supplied file")
 		return output
 	}
 

--- a/package-coverage/parser/line_parser.go
+++ b/package-coverage/parser/line_parser.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"fmt"
+	"log"
 	"strconv"
 	"strings"
 )
@@ -27,7 +27,7 @@ func parseLine(raw string) fragment {
 func extractPackage(raw string) string {
 	lastSlash := strings.LastIndex(raw, "/")
 	if lastSlash == -1 {
-		panic(fmt.Errorf("line skipped due to lack of package '%s'", raw))
+		log.Panicf("line skipped due to lack of package '%s'", raw)
 	}
 
 	return raw[:(lastSlash + 1)]
@@ -36,13 +36,13 @@ func extractPackage(raw string) string {
 func extractFile(raw string) string {
 	lastSlash := strings.LastIndex(raw, "/")
 	if lastSlash == -1 {
-		panic(fmt.Errorf("line skipped due to lack of package '%s'", raw))
+		log.Panicf("line skipped due to lack of package '%s'", raw)
 	}
 
 	fileAndLines := raw[(lastSlash + 1):]
 	line := strings.LastIndex(fileAndLines, ":")
 	if line == -1 {
-		panic(fmt.Errorf("line skipped due to lack of line number '%s'", raw))
+		log.Panicf("line skipped due to lack of line number '%s'", raw)
 	}
 
 	return fileAndLines[:line]
@@ -51,7 +51,7 @@ func extractFile(raw string) string {
 func extractNumbers(raw string) (int, bool) {
 	parts := strings.Split(raw, " ")
 	if len(parts) != 3 {
-		panic(fmt.Errorf("invalid line format. parts found %d, expected 3", len(parts)))
+		log.Panicf("invalid line format. parts found %d, expected 3", len(parts))
 	}
 
 	lines := extractStatements(parts[1])

--- a/package-coverage/parser/slack_coverage.go
+++ b/package-coverage/parser/slack_coverage.go
@@ -102,6 +102,6 @@ func sendToSlack(webHook string, attachments string) {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := ioutil.ReadAll(resp.Body)
-		panic(fmt.Sprintf("unexpected response code %d; body: %s; payload: %s", resp.StatusCode, body, message))
+		log.Panicf("unexpected response code %d; body: %s; payload: %s", resp.StatusCode, body, message)
 	}
 }

--- a/package-coverage/utils/directories.go
+++ b/package-coverage/utils/directories.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"go/build"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,7 +37,7 @@ func finder(basePath string, searchFor mode) ([]string, error) {
 
 	_ = filepath.Walk("./", func(path string, finfo os.FileInfo, err error) error {
 		if err != nil {
-			log.Printf("failed to check path '%s' with error %s", path, err)
+			LogWhenVerbose("failed to check path '%s' with error %s", path, err)
 			return nil
 		}
 
@@ -120,7 +119,7 @@ func hiddenOrSystemDirs(pathEnd string) bool {
 func hasGoFiles(path string) bool {
 	if _, err := build.ImportDir(path, 0); err != nil {
 		if _, noGo := err.(*build.NoGoError); !noGo {
-			log.Print(err)
+			LogWhenVerbose("unexpected error parsing go files. err: %s", err)
 		}
 		return false
 	}


### PR DESCRIPTION
- Removed duplication in Gonerator code
- Refactored cleaner to interface based; added some tests and retested clean flag
- Restored previous functionality of suppressing go test output and added option to output it
- Converted logging code to use custom logger