### PR TITLE
Change output format to show local package and branch

### DIFF
--- a/package-coverage/parser/coverage.go
+++ b/package-coverage/parser/coverage.go
@@ -73,10 +73,18 @@ func getSortedPackages(coverageData coverageByPackage) []string {
 	return output
 }
 
-// calculate the coverage and statement counts from the supplied data
-func getStats(cover *coverage) (float64, float64) {
+func getSummaryValues(cover *coverage) (float64, float64) {
 	stmts := float64(cover.selfStatements + cover.childStatements)
 	stmtsCovered := float64(cover.selfCovered + cover.childCovered)
+
+	covered := (stmtsCovered / stmts) * 100
+
+	return covered, stmts
+}
+
+func getSelfValues(cover *coverage) (float64, float64) {
+	stmts := float64(cover.selfStatements)
+	stmtsCovered := float64(cover.selfCovered)
 
 	covered := (stmtsCovered / stmts) * 100
 

--- a/package-coverage/parser/slack_coverage.go
+++ b/package-coverage/parser/slack_coverage.go
@@ -65,7 +65,7 @@ func prepareAndSendToSlack(pkgs []string, coverageData coverageByPackage, webhoo
 
 	for _, pkg := range pkgs {
 		cover := coverageData[pkg]
-		covered, statements := getStats(cover)
+		covered, statements := getSummaryValues(cover)
 
 		pkgFormatted := strings.Replace(pkg, prefix, "", -1)
 		pkgDepth := strings.Count(pkgFormatted, "/")


### PR DESCRIPTION
Old Format:
```
  %		Statements	Package
34.49		  461		github.com/corsc/go-tools/package-coverage/
45.08		  122		github.com/corsc/go-tools/package-coverage/generator/
34.39		  189		github.com/corsc/go-tools/package-coverage/parser/
65.00		   60		github.com/corsc/go-tools/package-coverage/utils/
```

New Format:
```
------------------------------------------------------------------------------------------------------------------------
|      Branch     |       Dir       |                                                                                  |
|   Cov% |  Stmts |   Cov% |  Stmts | Package                                                                          |
------------------------------------------------------------------------------------------------------------------------
|  34.49 |    461 |   0.00 |     90 | github.com/corsc/go-tools/package-coverage/                                      |
|  45.08 |    122 |  45.08 |    122 | github.com/corsc/go-tools/package-coverage/generator/                            |
|  34.39 |    189 |  34.39 |    189 | github.com/corsc/go-tools/package-coverage/parser/                               |
|  65.00 |     60 |  65.00 |     60 | github.com/corsc/go-tools/package-coverage/utils/                                |
------------------------------------------------------------------------------------------------------------------------
```