### PR TITLE
fix method has no params and no return bug

### DIFF
--- a/gonerator/tmpl/methods.go
+++ b/gonerator/tmpl/methods.go
@@ -76,9 +76,14 @@ func GetMethods(file *ast.File, typeName string) []Method {
 }
 
 func extractParamsAndResults(fnDesl *ast.FuncType) ([]MethodField, []MethodField) {
-	params := extractFieldsFromAst(fnDesl.Params.List)
-	results := extractFieldsFromAst(fnDesl.Results.List)
-
+	var params []MethodField
+	var results []MethodField
+	if fnDesl.Params.List != nil {
+		params = extractFieldsFromAst(fnDesl.Params.List)
+	}
+	if fnDesl.Results.List != nil {
+		results = extractFieldsFromAst(fnDesl.Results.List)
+	}
 	return params, results
 }
 


### PR DESCRIPTION
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1195f70]

such as if your interface like this
type test interface { MyTest() }

the error code is
`
func extractParamsAndResults(fnDesl *ast.FuncType) ([]MethodField, []MethodField) {
params := extractFieldsFromAst(fnDesl.Params.List)
results := extractFieldsFromAst(fnDesl.Results.List)

return params, results
}
`

you should change it like this
`
func extractParamsAndResults(fnDesl *ast.FuncType) ([]MethodField, []MethodField) {
var params []MethodField
var results []MethodField
if fnDesl.Params.List != nil {
params = extractFieldsFromAst(fnDesl.Params.List)
}

if fnDesl.Results.List != nil {
	results = extractFieldsFromAst(fnDesl.Results.List)
}

return params, results
}
`