### PR TITLE
make "ThisCodeDoesntReallyDoAnything" un-exported

### DIFF
--- a/package-coverage/main.go
+++ b/package-coverage/main.go
@@ -32,7 +32,6 @@ func main() {
 			fmt.Printf("Error: %s\n", r)
 		}
 	}()
-	fmt.Println("debug log")
 
 	// get config and environment
 	cfg := config.GetConfig()

--- a/package-coverage/main.go
+++ b/package-coverage/main.go
@@ -32,6 +32,7 @@ func main() {
 			fmt.Printf("Error: %s\n", r)
 		}
 	}()
+	fmt.Println("debug log")
 
 	// get config and environment
 	cfg := config.GetConfig()


### PR DESCRIPTION
Hello

We are using package-coverage to calculate test coverage but we have observed errors like -

```
2021/06/19 00:38:29 failed to get test command output. dir: /go/src/bitbucket.org/settlement-service/api/ err: exit status 2
2021/06/19 00:38:29 [coverage] test output /go/src/bitbucket.org/settlement-service/api/:
# bitbucket.org/settlement-service/cashout_service/cashout_consumer
../cashout_service/cashout_consumer/paysi_cashout_consumer.go:12:2: ThisCodeDoesntReallyDoAnything redeclared during import "bitbucket.org/settlement-service/dto"
	previous declaration at ../cashout_service/cashout_consumer/fake_code.go:3:6
FAIL	bitbucket.org/settlement-service/api [build failed]
```

This PR converts _ThisCodeDoesntReallyDoAnything_ to _thisCodeDoesntReallyDoAnything_ so that there are no redeclaration of this function.