### PR TITLE
Fixed the issue that double quote got escaped in exec

### DIFF
--- a/package-coverage/generator/coverage.go
+++ b/package-coverage/generator/coverage.go
@@ -200,7 +200,7 @@ func execCoverage(dir string, quiet, race bool, tags string) error {
 	}
 
 	if len(tags) > 0 {
-		arguments = append(arguments, `-tags="`+tags+`"`)
+		arguments = append(arguments, `-tags='`+tags+`'`)
 	}
 
 	cmd := exec.Command("go", arguments...)


### PR DESCRIPTION
I tested in Mac and docker environments, but both cannot work, after I changed the double quote to single quote, it works.